### PR TITLE
Fix rewrite rule in nginx.conf

### DIFF
--- a/docker/main/rootfs/usr/local/nginx/conf/nginx.conf
+++ b/docker/main/rootfs/usr/local/nginx/conf/nginx.conf
@@ -238,14 +238,14 @@ http {
 
             location /api/stats {
                 access_log off;
-                rewrite ^/api/(.*)$ $1 break;
+                rewrite ^/api(/.*)$ $1 break;
                 proxy_pass http://frigate_api;
                 include proxy.conf;
             }
 
             location /api/version {
                 access_log off;
-                rewrite ^/api/(.*)$ $1 break;
+                rewrite ^/api(/.*)$ $1 break;
                 proxy_pass http://frigate_api;
                 include proxy.conf;
             }


### PR DESCRIPTION
Include leading slash of path in rewrite rule for frigate_api in nginx.conf

Noticed the healthcheck curl requests were failing as they were routed to http://127.0.0.1:5001version instead of http://127.0.0.1:5001/version